### PR TITLE
[WFLY-17451] Register a requirement for the filter capability in the …

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -91,7 +91,7 @@ class HostDefinition extends SimpleResourceDefinition {
         registration.registerSubModel(new LocationDefinition());
         registration.registerSubModel(new AccessLogDefinition());
         registration.registerSubModel(new ConsoleAccessLogDefinition());
-        registration.registerSubModel(new FilterRefDefinition());
+        registration.registerSubModel(new FilterRefDefinition(true));
         registration.registerSubModel(new HttpInvokerDefinition());
         new HostSingleSignOnDefinition().register(registration, null);
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
@@ -54,6 +54,6 @@ class LocationDefinition extends PersistentResourceDefinition {
 
     @Override
     public List<? extends PersistentResourceDefinition> getChildren() {
-        return List.of(new FilterRefDefinition());
+        return List.of(new FilterRefDefinition(false));
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterCapabilities.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterCapabilities.java
@@ -41,24 +41,25 @@ import org.wildfly.extension.undertow.UndertowFilter;
  */
 enum FilterCapabilities implements Capability {
 
-    FILTER_CAPABILITY(CAPABILITY_FILTER, PredicateHandlerWrapper.class),
+    FILTER_CAPABILITY(CAPABILITY_FILTER, PredicateHandlerWrapper.class, UnaryCapabilityNameResolver.DEFAULT),
     FILTER_HOST_REF_CAPABILITY(CAPABILITY_HOST_FILTER_REF, UndertowFilter.class, TernaryCapabilityNameResolver.GRANDPARENT_PARENT_CHILD),
     FILTER_LOCATION_REF_CAPABILITY(CAPABILITY_LOCATION_FILTER_REF, UndertowFilter.class, QuaternaryCapabilityNameResolver.GREATGRANDPARENT_GRANDPARENT_PARENT_CHILD);
 
     private final RuntimeCapability<Void> definition;
-
-    FilterCapabilities(String name, Class<?> serviceValueType) {
-        this.definition = RuntimeCapability.Builder.of(name, true, serviceValueType)
-                .setDynamicNameMapper(UnaryCapabilityNameResolver.DEFAULT).build();
-    }
+    private final Function<PathAddress, String[]> nameResolver;
 
     FilterCapabilities(String name, Class<?> serviceValueType, Function<PathAddress, String[]> nameResolver) {
         this.definition = RuntimeCapability.Builder.of(name, true, serviceValueType)
                 .setDynamicNameMapper(nameResolver).build();
+        this.nameResolver = nameResolver;
     }
 
     @Override
     public RuntimeCapability<Void> getDefinition() {
         return this.definition;
+    }
+
+    public Function<PathAddress, String[]> getDynamicNameMapper() {
+        return nameResolver;
     }
 }


### PR DESCRIPTION
…Stage.MODEL handling for adding a filter-ref.

Unfortunately, Galleon feature spec generation won't let us record it via FilterResourceRegistration.

Also, statically parameterize FilterRefDefinition and FilterRefAdd instances so they know if they are for direct children of 'host' or for children of 'location'


