### PR TITLE
[WFLY-19808] Move UndertowSubsystemModel to VERSION_15_0_0; add mixed…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtensionTransformerRegistration.java
@@ -50,7 +50,7 @@ public class UndertowExtensionTransformerRegistration implements ExtensionTransf
                 }
             }
 
-            if (UndertowSubsystemModel.VERSION_14_0_0.requiresTransformation(version)) {
+            if (UndertowSubsystemModel.VERSION_15_0_0.requiresTransformation(version)) {
                 final ResourceTransformationDescriptionBuilder handlers = subsystem.addChildResource(HandlerDefinitions.PATH_ELEMENT);
                 final ResourceTransformationDescriptionBuilder reverseProxy = handlers.addChildResource(ReverseProxyHandlerDefinition.PATH_ELEMENT);
                 final AttributeTransformationDescriptionBuilder reverseProxyAttributeTransformationDescriptionBuilder = reverseProxy.getAttributeBuilder();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemModel.java
@@ -18,8 +18,9 @@ public enum UndertowSubsystemModel implements SubsystemModel {
     VERSION_12_0_0(12), // WildFly 27
     VERSION_13_0_0(13), // WildFly 28
     VERSION_14_0_0(14), // WildFly 32-present
+    VERSION_15_0_0(15), // WildFly 32-present
     ;
-    static final UndertowSubsystemModel CURRENT = VERSION_14_0_0;
+    static final UndertowSubsystemModel CURRENT = VERSION_15_0_0;
 
     private final ModelVersion version;
 

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform-reject.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform-reject.xml
@@ -3,8 +3,10 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:14.0" default-server="default-server" default-servlet-container="default-container" default-virtual-host="default-host" instance-id="foo">
+<subsystem xmlns="urn:jboss:domain:undertow:15.0" default-server="default-server" default-servlet-container="default-container" default-virtual-host="default-host" instance-id="foo">
+    <byte-buffer-pool name="default" thread-local-cache-size="45" buffer-size="1000" direct="false" leak-detection-percent="50" max-pool-size="1000"/>
     <server name="default-server" default-host="default-host">
+        <ajp-listener name="ajp" allowed-request-attributes-pattern="test" socket-binding="ajp"/>
         <host name="default-host"/>
     </server>
     <servlet-container name="default-container"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-transform.xml
@@ -3,7 +3,7 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:14.0" default-server="default-server" default-servlet-container="default-container" default-virtual-host="default-host" instance-id="foo">
+<subsystem xmlns="urn:jboss:domain:undertow:15.0" default-server="default-server" default-servlet-container="default-container" default-virtual-host="default-host" instance-id="foo">
     <server name="default-server" default-host="default-host">
         <ajp-listener name="ajp" socket-binding="ajp"/>
         <http-listener name="http" socket-binding="http"/>


### PR DESCRIPTION
… domain testing

We need a 15 version to:

* allow domain mode transformation, where a legacy HC could report it is running version 14. The WF 40 HC needs to know it is newer.
* so if someone doing a read-resource-description against two server running at 'default' stability, one WF 40 and one WF 39 doesn't see info saying the API version is 14 on both but one shows "allowed-request-attributes-pattern" as being an available attribute and the other doesn't. 

I added testing against a version 14 server (EAP 8.1) to UndertowSubsystemTransformerTestCase.
